### PR TITLE
Cleanup

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -237,10 +237,6 @@ function addKeyset(doc) {
 	
 	let keyset = doc.createElement ('keyset');
 	keyset.setAttribute("id", "personaSwitcherKeyset")
-    // a way to find the keyset no matter what.
-    let breadCrumb = doc.createElement ('key');
-    breadCrumb.setAttribute ('id', 'PersonaSwitcher.keyBreadCrumb'); 
-    keyset.appendChild (breadCrumb);
 	mainWindow.appendChild(keyset);	
 }
 

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -108,24 +108,16 @@ function injectMainMenu(doc) {
 	let menu_tools;
 	switch (PersonaSwitcher.XULAppInfo.name)
 	{
+		case 'Icedove':
 		case 'Thunderbird':
-			menuBar = doc.getElementById("mail-menubar");
-			menu_tools = doc.getElementById("tasksMenu");
-			break;
 		case 'SeaMonkey':
 			menuBar = doc.getElementById("main-menubar");			
 			menu_tools = doc.getElementById("tasksMenu");
 			break;
-		case 'Icedove':
-			menuBar = doc.getElementById("mail-menubar");
-			menu_tools = doc.getElementById("tasksMenu");
-			break;
 		case 'Firefox':
+		default:
 			menuBar = doc.getElementById("main-menubar");			
 			menu_tools = doc.getElementById("tools-menu");
-			break;
-		default:
-			//Shouldn't get here
 			break;
 	}
 		
@@ -150,20 +142,14 @@ function injectSubMenu(doc) {
 	let subMenu_prefs;
 	switch (PersonaSwitcher.XULAppInfo.name)
 	{
+		case 'Icedove':
 		case 'Thunderbird':
-			menuPopup = doc.getElementById("taskPopup");
-			break;
 		case 'SeaMonkey':
 			menuPopup = doc.getElementById("taskPopup");
 			break;
-		case 'Icedove':
-			menuPopup = doc.getElementById("taskPopup");
-			break;
 		case 'Firefox':
-			menuPopup = doc.getElementById("menu_ToolsPopup");
-			break;
 		default:
-			//Shouldn't get here
+			menuPopup = doc.getElementById("menu_ToolsPopup");
 			break;
 	}
 	
@@ -187,20 +173,14 @@ function injectButton(doc) {
 	let toolbox;
 	switch (PersonaSwitcher.XULAppInfo.name)
 	{
+		case 'Icedove':
 		case 'Thunderbird':
 			toolbox = doc.getElementById("mail-toolbox");
 			break;
 		case 'SeaMonkey':
-			toolbox = doc.getElementById("navigator-toolbox");
-			break;
-		case 'Icedove':
-			toolbox = doc.getElementById("mail-toolbox");
-			break;
 		case 'Firefox':
-			toolbox = doc.getElementById("navigator-toolbox");
-			break;
 		default:
-			//Shouldn't get here
+			toolbox = doc.getElementById("navigator-toolbox");
 			break;
 	}
 	//PersonaSwitcher button added to the customize toolbox
@@ -226,24 +206,16 @@ function injectButton(doc) {
 function moveButtonToToolbar(doc) {
 	switch (PersonaSwitcher.XULAppInfo.name)
 	{
+		case 'Icedove':
 		case 'Thunderbird':
 			var tabbar = doc.getElementById('tabbar-toolbar');
 			tabbar.insertItem("personaswitcher-button");
 			break;
 		case 'SeaMonkey':
-			var navBar = doc.querySelector('#nav-bar');
-			navBar.insertItem("personaswitcher-button");
-			break;
-		case 'Icedove':
-			var tabbar = doc.getElementById('tabbar-toolbar');
-			tabbar.insertItem("personaswitcher-button");
-			break;
 		case 'Firefox':
+		default:
 			var navBar = doc.querySelector('#nav-bar');
 			navBar.insertItem("personaswitcher-button");
-			break;
-		default:
-			//Shouldn't get here
 			break;
 	}
 }
@@ -252,20 +224,14 @@ function addKeyset(doc) {
 	var mainWindow;
 	switch (PersonaSwitcher.XULAppInfo.name)
 	{
+		case 'Icedove':
 		case 'Thunderbird':
 			mainWindow = doc.getElementById('messengerWindow');
 			break;
 		case 'SeaMonkey':
-			mainWindow = doc.getElementById('main-window');
-			break;
-		case 'Icedove':
-			mainWindow = doc.getElementById('messengerWindow');
-			break;
 		case 'Firefox':
-			mainWindow = doc.getElementById('main-window');
-			break;
 		default:
-			//Shouldn't get here
+			mainWindow = doc.getElementById('main-window');
 			break;
 	}
 	

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -2,13 +2,11 @@ const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 Cu.import('resource://gre/modules/Services.jsm');
 Cu.import('resource://gre/modules/devtools/Console.jsm');
 
-
 var stringBundle = Services.strings.createBundle('chrome://personaswitcher/locale/personaswitcher.properties?' + Math.random());
 
 function startup(data, reason) {
   Cu.import('chrome://personaswitcher/content/PersonaSwitcher.jsm');
 
-  //https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/mozIJSSubScriptLoader
   //https://developer.mozilla.org/en-US/Add-ons/Overlay_Extensions/XUL_School/Appendix_D:_Loading_Scripts
   //load preferences
   Services.scriptloader.loadSubScript('chrome://personaswitcher/content/prefs.js', {
@@ -20,6 +18,7 @@ function startup(data, reason) {
   uri = Services.io.newURI("chrome://personaswitcher/skin/toolbar-button.css", null, null);
   styleSheetService.loadAndRegisterSheet(uri, styleSheetService.USER_SHEET);
 
+  //https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/mozIJSSubScriptLoader
   let context = this;
   Services.scriptloader.loadSubScript('chrome://personaswitcher/content/ui.js',
                                     context, "UTF-8" /* The script's encoding */);
@@ -27,6 +26,7 @@ function startup(data, reason) {
   forEachOpenWindow(loadIntoWindow);
   Services.wm.addListener(WindowListener);  
 }
+
 function shutdown(data, reason) {
 
   //Clears the cache on disable so reloading the addon when debugging works properly
@@ -34,7 +34,8 @@ function shutdown(data, reason) {
   if (reason == ADDON_DISABLE) {
     Services.obs.notifyObservers(null, "startupcache-invalidate", null);
   }
-
+	
+	Cu.unload('chrome://personaswitcher/content/PersonaSwitcher.jsm');	
   forEachOpenWindow(unloadFromWindow);
   Services.wm.removeListener(WindowListener);
   
@@ -42,16 +43,20 @@ function shutdown(data, reason) {
     styleSheetService.unregisterSheet(uri, styleSheetService.USER_SHEET);
   }
   
+	//https://developer.mozilla.org/en-US/Add-ons/How_to_convert_an_overlay_extension_to_restartless#Step_10_Bypass_cache_when_loading_properties_files/
   // HACK WARNING: The Addon Manager does not properly clear all addon related caches on update;
   //               in order to fully update images and locales, their caches need clearing here
   Services.obs.notifyObservers(null, 'chrome-flush-caches', null);
 }
+
 function install(data, reason) {
 	//Installation happens here
 }
+
 function uninstall(data, reason) {
 	//Uninstall happens here
 }
+
 function loadIntoWindow(window) {		
 	let doc = window.document;
 	
@@ -61,6 +66,7 @@ function loadIntoWindow(window) {
 	addKeyset(doc);	
 	PersonaSwitcher.onWindowLoad(doc);
 }
+
 function unloadFromWindow(window) {
 	let doc = window.document;
 	let menu_personaswitcher = doc.getElementById("personaswitcher-main-menubar");	
@@ -81,10 +87,12 @@ function unloadFromWindow(window) {
 		keySet.parentNode.removeChild(keySet);
 	}
 }
+
 function forEachOpenWindow(applyThisFunc) // Apply a function to all open browser windows
 {
 	PersonaSwitcher.allWindows(applyThisFunc);
 }
+
 var WindowListener = {
   onOpenWindow: function (xulWindow)
   {
@@ -102,6 +110,7 @@ var WindowListener = {
   onWindowTitleChange: function (xulWindow, newTitle) {
   }
 } 
+
 //UI Injection
 function injectMainMenu(doc) {
 	let menuBar;
@@ -203,6 +212,7 @@ function injectButton(doc) {
 
 	moveButtonToToolbar(doc);
 }
+
 function moveButtonToToolbar(doc) {
 	switch (PersonaSwitcher.XULAppInfo.name)
 	{
@@ -219,6 +229,7 @@ function moveButtonToToolbar(doc) {
 			break;
 	}
 }
+
 function addKeyset(doc) {
 	//http://forums.mozillazine.org/viewtopic.php?t=2711165
 	var mainWindow;
@@ -246,6 +257,7 @@ function loadStyleSheet(window) {
 	  getInterface(Components.interfaces.nsIDOMWindowUtils).loadSheet(this._uri, 1);
 }
 
+//https://developer.mozilla.org/en-US/Add-ons/How_to_convert_an_overlay_extension_to_restartless#Step_4_Manually_handle_default_preferences
 //Default Preferences Setup
 function getGenericPref(branch, prefName)
 {
@@ -262,6 +274,7 @@ function getGenericPref(branch, prefName)
       return branch.getBoolPref(prefName); // PREF_BOOL
   }
 }
+
 function setGenericPref(branch, prefName, prefValue)
 {
   switch (typeof prefValue)
@@ -277,6 +290,7 @@ function setGenericPref(branch, prefName, prefValue)
       return;
   }
 }
+
 function setDefaultPref(prefName, prefValue)
 {
   var defaultBranch = Services.prefs.getDefaultBranch(null);

--- a/chrome/content/PersonaSwitcher.jsm
+++ b/chrome/content/PersonaSwitcher.jsm
@@ -1,5 +1,4 @@
 //https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/XUL_Reference
-
 // https://developer.mozilla.org/en/JavaScript_code_modules/Using_JavaScript_code_modules
 
 // no space between comment delimiters. really.
@@ -126,6 +125,10 @@ PersonaSwitcher.activeWindow = null;
 PersonaSwitcher.previewWhich = null;
 PersonaSwitcher.staticPopups = false;
 
+//Default theme set to an object with an id property equal to the hard coded default theme id value
+//Necessary for Icedove compatibility as Icedove's default theme id is not the same, and thus cannot
+//be found using the same defaultThemeId. If Icedove's default theme id can be acquired, defaultTheme
+//can be set back to null and the correct id can be queried instead.
 PersonaSwitcher.defaultTheme = {id:'{972ce4c6-7e08-4474-a285-3208198ce6fd}'};
 PersonaSwitcher.defaultThemeId = '{972ce4c6-7e08-4474-a285-3208198ce6fd}';
 

--- a/chrome/content/ui.js
+++ b/chrome/content/ui.js
@@ -9,14 +9,10 @@
 //Services
 Components.utils.import('resource://gre/modules/Services.jsm');
 // 'import' for jslint
-Components.utils['import']
-    ('resource://gre/modules/LightweightThemeManager.jsm');
-//Components.utils['import']('chrome://personaswitcher/content/PersonaSwitcher.jsm');
+Components.utils.import('resource://gre/modules/LightweightThemeManager.jsm');
 
 PersonaSwitcher.XULNS =
     'http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul';
-	
-//var EXPORTED_SYMBOLS = ["PersonaSwitcher"];
 
 /*
 ***************************************************************************
@@ -135,7 +131,6 @@ PersonaSwitcher.setKeyset = function (doc)
 };
 
 // https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Tutorial/Keyboard_Shortcuts#Assigning_a_keyboard_shortcut_on_a_menu
-
 PersonaSwitcher.activateMenu = function(doc)
 {
     PersonaSwitcher.logger.log();
@@ -329,7 +324,7 @@ PersonaSwitcher.createMenuItem = function (doc, which)
     item.addEventListener
     (
         'command',
-        function() { PersonaSwitcher.onMenuItemCommand (which); },
+        function() { PersonaSwitcher.onMenuItemCommand(which); },
         false
     );
 
@@ -428,15 +423,15 @@ PersonaSwitcher.createMenuItems = function (doc, menupopup, arr)
     */
 
     var item = null;
-    if (null !== PersonaSwitcher.defaultTheme)
-    {
+    //if (!PM && !TB && null !== PersonaSwitcher.defaultTheme)
+    //{
         item = PersonaSwitcher.createMenuItem
             (doc, PersonaSwitcher.defaultTheme);
         if (item)
         {
             menupopup.appendChild (item);
         }
-    }
+    //}
 
     // arr.sort (function (a, b) { return a.name.localeCompare (b.name); });
 
@@ -540,6 +535,8 @@ PersonaSwitcher.showMenus = function (which)
     }
 };
 
+//Appears to have been a Hack to get popupHidden to work in non-Firefox applications
+//Is no longer being called anywhere. Remove?
 PersonaSwitcher.popupShowing = function (event)
 {
     PersonaSwitcher.logger.log ("in popupShowing");
@@ -687,7 +684,7 @@ PersonaSwitcher.onWindowLoad = function (doc)
 {
     if (PersonaSwitcher.firstTime)
     {
-        //PersonaSwitcher.firstTime = false;
+        PersonaSwitcher.firstTime = false;
 
         // PersonaSwitcher.activeWindow = this;
         PersonaSwitcher.setLogger();
@@ -698,7 +695,7 @@ PersonaSwitcher.onWindowLoad = function (doc)
 
         // this also sets up the menus as there is an asynchronous call to
         // addon manager. bleah.
-        PersonaSwitcher.setDefaultTheme (doc);
+        PersonaSwitcher.setDefaultTheme(doc);
 
         PersonaSwitcher.currentIndex =
             PersonaSwitcher.prefs.getIntPref ("current");

--- a/chrome/content/ui.js
+++ b/chrome/content/ui.js
@@ -74,26 +74,19 @@ PersonaSwitcher.setKeyset = function (doc)
 {
     PersonaSwitcher.logger.log (doc);
 
-    var existing = doc.getElementById ('PersonaSwitcher.keyBreadCrumb');
-    PersonaSwitcher.logger.log (existing);
+    var oldKeyset = doc.getElementById ('personaSwitcherKeyset');
+    PersonaSwitcher.logger.log (oldKeyset);
 
     // there are windows/documents that don't have keyset -- e.g.: prefs
-    if (null === existing) return;
+    if (null === oldKeyset) return;
 
-    var parent = existing.parentNode;
-    // PersonaSwitcher.logger.log (parent);
-    var grandParent = parent.parentNode;
-    // PersonaSwitcher.logger.log (grandParent);
+    var parent = oldKeyset.parentNode;
+    // PersonaSwitcher.logger.log (oldKeyset);
 
-    // remove the existing keyset and make a brand new one
-    grandParent.removeChild (parent);
+    // remove the old keyset and make a brand new one
+    parent.removeChild (oldKeyset);
     var keyset = doc.createElement ('keyset');
-	keyset.setAttribute("id", "personaSwitcherKeyset");
-
-    // a way to find the keyset no matter what.
-    var breadCrumb = doc.createElement ('key');
-    breadCrumb.setAttribute ('id', 'PersonaSwitcher.keyBreadCrumb'); 
-    keyset.appendChild (breadCrumb);
+	  keyset.setAttribute("id", "personaSwitcherKeyset");
 
     var keys =
     [
@@ -138,7 +131,7 @@ PersonaSwitcher.setKeyset = function (doc)
         keyset.appendChild (newKey);
     }
 
-    grandParent.appendChild (keyset);
+    parent.appendChild (keyset);
 };
 
 // https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Tutorial/Keyboard_Shortcuts#Assigning_a_keyboard_shortcut_on_a_menu


### PR DESCRIPTION
Cleaned up the application checking switch statements to remove duplicate code and instead allow case fall through.

Keysets can now contain an id attribute. As such, added an id to the keyset and removed the breadcrumb key and associated code that provided the ability to retrieve id-less keysets.

General formatting cleanup and documentation 