### PR TITLE
Functionality Migration and Bug Fixes

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -3,6 +3,8 @@ Cu.import('resource://gre/modules/Services.jsm');
 Cu.import("resource://gre/modules/Console.jsm");
 
 var stringBundle = Services.strings.createBundle('chrome://personaswitcher/locale/personaswitcher.properties?' + Math.random());
+var styleSheetService = Cc["@mozilla.org/content/style-sheet-service;1"].getService(Ci.nsIStyleSheetService);
+var uri = Services.io.newURI("chrome://personaswitcher/skin/toolbar-button.css", null, null);
 
 function startup(data, reason) {	
 	//https://developer.mozilla.org/en-US/Add-ons/Overlay_Extensions/XUL_School/Appendix_D:_Loading_Scripts
@@ -20,8 +22,6 @@ function startup(data, reason) {
 
   //https://blog.mozilla.org/addons/2014/03/06/australis-for-add-on-developers-2/
   //Loading the stylesheet into all windows is a noticable hit on performance but is necessary for Thunderbird compatibility
-  styleSheetService = Cc["@mozilla.org/content/style-sheet-service;1"].getService(Ci.nsIStyleSheetService);
-  uri = Services.io.newURI("chrome://personaswitcher/skin/toolbar-button.css", null, null);
   styleSheetService.loadAndRegisterSheet(uri, styleSheetService.USER_SHEET);
 
 																		
@@ -120,7 +120,8 @@ var WindowListener = {
   },
   onWindowTitleChange: function (xulWindow, newTitle) {
   }
-} 
+};
+
 //Message handler for communication with embedded WebExtension
 function messageHandler(message, sender, sendResponse) {
 	 switch (message.command)
@@ -149,6 +150,7 @@ function messageHandler(message, sender, sendResponse) {
 			break;
 		case "Get-Current-Index":
 			sendResponse({current: PersonaSwitcher.currentIndex});
+			break;
 		case "Set-Preference":
 			setPreference(message.preference, message.value);
 			break;
@@ -322,7 +324,6 @@ function injectMainMenu(doc) {
 
 function injectSubMenu(doc) {
 	let menuPopup;
-	let subMenu_prefs;
 	switch (PersonaSwitcher.XULAppInfo.name)
 	{
 		case 'Icedove':
@@ -421,14 +422,8 @@ function addKeyset(doc) {
 	}
 	
 	let keyset = doc.createElement ('keyset');
-	keyset.setAttribute("id", "personaSwitcherKeyset")
+	keyset.setAttribute("id", "personaSwitcherKeyset");
 	mainWindow.appendChild(keyset);	
-}
-
-function loadStyleSheet(window) {		
-	this._uri = Services.io.newURI('chrome://personaswitcher/skin/toolbar-button.css', null, null);
-    window.QueryInterface(Components.interfaces.nsIInterfaceRequestor).
-	  getInterface(Components.interfaces.nsIDOMWindowUtils).loadSheet(this._uri, 1);
 }
 
 //https://developer.mozilla.org/en-US/Add-ons/How_to_convert_an_overlay_extension_to_restartless#Step_4_Manually_handle_default_preferences

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -127,7 +127,6 @@ function messageHandler(message, sender, sendResponse) {
 	   case "Return-Theme-List":
        PersonaSwitcher.getPersonas();
 		   var themeList = PersonaSwitcher.currentThemes;
-		   themeList.sort (function (a, b) { return a.name.localeCompare (b.name); });
 		   var defaultTheme = {id: PersonaSwitcher.defaultTheme.id, name: PersonaSwitcher.defaultTheme.name, iconURL: PersonaSwitcher.defaultTheme.iconURL};
 		   themeList.push(defaultTheme);
 		   sendResponse({themes: themeList});

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -63,9 +63,7 @@ function install(data, reason) {
 }
 
 function uninstall(data, reason) {
-	if(ADDON_UNINSTALL === reason) {
 		removeUserPrefs();
-	}
 }
 
 function loadIntoWindow(window) {		

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -127,6 +127,7 @@ function messageHandler(message, sender, sendResponse) {
 	   case "Return-Theme-List":
        PersonaSwitcher.getPersonas();
 		   var themeList = PersonaSwitcher.currentThemes;
+		   themeList.sort (function (a, b) { return a.name.localeCompare (b.name); });
 		   var defaultTheme = {id: PersonaSwitcher.defaultTheme.id, name: PersonaSwitcher.defaultTheme.name, iconURL: PersonaSwitcher.defaultTheme.iconURL};
 		   themeList.push(defaultTheme);
 		   sendResponse({themes: themeList});
@@ -480,66 +481,20 @@ function setUCharPref(prefName, text, branch) // Unicode setCharPref
 
 function removeUserPrefs() 
 {
+	var userPreferences = [
+	"defshift", "defcontrol", "defalt", "defmeta", "defaccel", "defos", "defkey",
+	"rotshift", "rotcontrol", "rotalt", "rotmeta", "rotaccel", "rotos", "rotkey",
+	"autoshift", "autocontrol", "autoalt", "autometa", "autoaccel", "autoos", "autokey",
+	"activateshift", "activatecontrol", "activatealt", "activatemeta", "activateaccel", "activateos", "activatekey",
+	"accesskey", "auto", "autominutes", "random", "preview", "preview-delay", "icon-preview",
+	"tools-submenu", "main-menubar", "debug", "notification-workaround", "toolbox-minheight",
+	"startup-switch", "fastswitch", "current"];
+	
 	var userBranch = Components.classes["@mozilla.org/preferences-service;1"].
         getService(Components.interfaces.nsIPrefService).
             getBranch ("extensions.personaswitcher.");
-						
-	userBranch.clearUserPref("defshift");
-	userBranch.clearUserPref("defcontrol");
-	userBranch.clearUserPref("defalt");
-	userBranch.clearUserPref("defmeta");
-	userBranch.clearUserPref("defaccel");
-	userBranch.clearUserPref("defos");
-	userBranch.clearUserPref("defkey");
-
-	userBranch.clearUserPref("rotshift");
-	userBranch.clearUserPref("rotcontrol");
-	userBranch.clearUserPref("rotalt");
-	userBranch.clearUserPref("rotmeta");
-	userBranch.clearUserPref("rotaccel");
-	userBranch.clearUserPref("rotos");
-	userBranch.clearUserPref("rotkey");
-
-	userBranch.clearUserPref("autoshift");
-	userBranch.clearUserPref("autocontrol");
-	userBranch.clearUserPref("autoalt");
-	userBranch.clearUserPref("autometa");
-	userBranch.clearUserPref("autoaccel");
-	userBranch.clearUserPref("autoos");
-	userBranch.clearUserPref("autokey");
-
-	userBranch.clearUserPref("activateshift");
-	userBranch.clearUserPref("activatecontrol");
-	userBranch.clearUserPref("activatealt");
-	userBranch.clearUserPref("activatemeta");
-	userBranch.clearUserPref("activateaccel");
-	userBranch.clearUserPref("activateos");
-	userBranch.clearUserPref("activatekey");
-
-	userBranch.clearUserPref("accesskey");
-
-	userBranch.clearUserPref("auto");
-	userBranch.clearUserPref("autominutes");
-
-	userBranch.clearUserPref("random");
-
-	userBranch.clearUserPref("preview");
-	userBranch.clearUserPref("preview-delay");
-	userBranch.clearUserPref("icon-preview");
-
-	userBranch.clearUserPref("tools-submenu");
-	userBranch.clearUserPref("main-menubar");
-
-	userBranch.clearUserPref("debug");
-	userBranch.clearUserPref("notification-workaround");
-
-	userBranch.clearUserPref("toolbox-minheight");
-
-	userBranch.clearUserPref("startup-switch");
-
-	userBranch.clearUserPref("fastswitch");
-
-	userBranch.clearUserPref("static-popups");
-
-	userBranch.clearUserPref("current");
+	
+	for(var pref of userPreferences) {
+		userBranch.clearUserPref(pref);
+	}
 }

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -63,7 +63,9 @@ function install(data, reason) {
 }
 
 function uninstall(data, reason) {
-	removeUserPrefs();
+	if(ADDON_UNINSTALL === reason) {
+		removeUserPrefs();
+	}
 }
 
 function loadIntoWindow(window) {		

--- a/chrome.manifest
+++ b/chrome.manifest
@@ -1,5 +1,5 @@
-content   personaswitcher		    chrome/content/
-locale    personaswitcher	en-US	chrome/locale/en-US/
+content   personaswitcher		    	chrome/content/
+locale    personaswitcher	en-US		chrome/locale/en-US/
 locale    personaswitcher	zh-TW   chrome/locale/zh-TW/
 locale    personaswitcher	zh-CN   chrome/locale/zh-CN/
 locale    personaswitcher	de      chrome/locale/de/

--- a/chrome/content/PersonaSwitcher.jsm
+++ b/chrome/content/PersonaSwitcher.jsm
@@ -123,7 +123,7 @@ PersonaSwitcher.logger = console;
 PersonaSwitcher.firstTime = true;
 PersonaSwitcher.activeWindow = null;
 PersonaSwitcher.previewWhich = null;
-PersonaSwitcher.staticPopups = false;
+//PersonaSwitcher.staticPopups = false;
 
 //Default theme set to an object with an id property equal to the hard coded default theme id value
 //Necessary for Icedove compatibility as Icedove's default theme id is not the same, and thus cannot
@@ -180,7 +180,7 @@ PersonaSwitcher.prefsObserver =
                 PersonaSwitcher.allDocuments
                     (PersonaSwitcher.setToolboxMinheight);
                 break;
-            case 'static-popups':
+            /*case 'static-popups':
                 if (PersonaSwitcher.prefs.getBoolPref ('static-popups'))
                 {
                     PersonaSwitcher.allDocuments
@@ -191,7 +191,7 @@ PersonaSwitcher.prefsObserver =
                     PersonaSwitcher.allDocuments
                         (PersonaSwitcher.removeStaticPopups);
                 }
-                break;		
+                break;		*/
             case 'preview':
                 PersonaSwitcher.allDocuments
                     (PersonaSwitcher.createStaticPopups);

--- a/chrome/content/PersonaSwitcher.jsm
+++ b/chrome/content/PersonaSwitcher.jsm
@@ -5,7 +5,7 @@
 /*global Components*/
 /*jslint vars: false*/
 
-Components.utils.import('resource://gre/modules/devtools/Console.jsm');
+Components.utils.import("resource://gre/modules/Console.jsm");
 Components.utils["import"]
     ("resource://gre/modules/LightweightThemeManager.jsm");
 
@@ -196,17 +196,17 @@ PersonaSwitcher.prefsObserver =
                 PersonaSwitcher.allDocuments
                     (PersonaSwitcher.createStaticPopups);
                 break;	
-			case 'icon-preview':
+						case 'icon-preview':
                 PersonaSwitcher.allDocuments
                     (PersonaSwitcher.createStaticPopups);
                 break;			
             case 'startup-switch':
                 break; // nothing to do as the value is queried elsewhere
             case 'fastswitch':
-                PersonaSwitcher.startTimer();
+                //PersonaSwitcher.startTimer();
                 break;
             case 'auto':
-                if (PersonaSwitcher.prefs.getBoolPref ('auto'))
+                /*if (PersonaSwitcher.prefs.getBoolPref ('auto'))
                 {
                     PersonaSwitcher.startTimer();
                     PersonaSwitcher.rotate();
@@ -214,10 +214,10 @@ PersonaSwitcher.prefsObserver =
                 else
                 {
                     PersonaSwitcher.stopTimer();
-                }
+                }*/
                 break;
             case 'autominutes':
-                PersonaSwitcher.startTimer();
+                //PersonaSwitcher.startTimer();
                 break;
             case 'main-menubar': case 'tools-submenu':
                 if (PersonaSwitcher.prefs.getBoolPref (data))
@@ -263,6 +263,72 @@ PersonaSwitcher.prefsObserver =
 
 PersonaSwitcher.prefs.addObserver ('', PersonaSwitcher.prefsObserver, false);
 
+
+
+// call a function passed as a parameter with one document of each window
+PersonaSwitcher.allDocuments = function (func)
+{	
+	var enumerator = PersonaSwitcher.windowMediator.getEnumerator ("navigator:browser");
+	var aWindow;
+    while (enumerator.hasMoreElements())
+    {
+			aWindow = enumerator.getNext();
+			PersonaSwitcher.logger.log ('In allDocuments with ' + aWindow);
+			func(aWindow.document);
+    }
+};
+
+// call a function passed as a parameter for each window
+PersonaSwitcher.allWindows = function (func)
+{
+	var enumerator = PersonaSwitcher.windowMediator.getEnumerator ("navigator:browser");
+    while (enumerator.hasMoreElements())
+    {
+		func(enumerator.getNext());
+    }
+};
+
+PersonaSwitcher.hideMenu = function (doc, which)
+{
+    var d = doc.getElementById ('personaswitcher-' + which);
+    if (d) d.hidden = true;
+};
+
+/*
+** remove a particular menu in all windows
+*/
+PersonaSwitcher.hideMenus = function (which)
+{
+    PersonaSwitcher.logger.log (which);
+
+    var enumerator = PersonaSwitcher.windowMediator.getEnumerator (null);
+
+    while (enumerator.hasMoreElements())
+    {
+        var doc = enumerator.getNext().document;
+        PersonaSwitcher.hideMenu (doc, which);
+    }
+};
+
+PersonaSwitcher.showMenu = function (doc, which)
+{
+    var d = doc.getElementById ('personaswitcher-' + which);
+    if (d) d.hidden = false;
+};
+
+PersonaSwitcher.showMenus = function (which)
+{
+    PersonaSwitcher.logger.log (which);
+
+    var enumerator = PersonaSwitcher.windowMediator.getEnumerator (null);
+
+    while (enumerator.hasMoreElements())
+    {
+        var doc = enumerator.getNext().document;
+        PersonaSwitcher.showMenu (doc, which);
+    }
+};
+
 // ---------------------------------------------------------------------------
 
 /*
@@ -277,9 +343,12 @@ PersonaSwitcher.rotate = function()
 
     if (PersonaSwitcher.prefs.getBoolPref ('random'))
     {
-        // pick a number between 1 and the end
+			var prevIndex = PersonaSwitcher.currentIndex;
+			// pick a number between 1 and the end until a new index is found
+			while(PersonaSwitcher.currentIndex === prevIndex) {
         PersonaSwitcher.currentIndex = Math.floor ((Math.random() *
             (PersonaSwitcher.currentThemes.length-1)) + 1);
+			}
     }
     else
     {
@@ -295,7 +364,7 @@ PersonaSwitcher.rotate = function()
 
 // ---------------------------------------------------------------------------
 
-PersonaSwitcher.timer = Components.classes['@mozilla.org/timer;1'].
+/*PersonaSwitcher.timer = Components.classes['@mozilla.org/timer;1'].
     createInstance(Components.interfaces.nsITimer);
 
 PersonaSwitcher.timerObserver =
@@ -333,7 +402,7 @@ PersonaSwitcher.stopTimer = function()
     PersonaSwitcher.logger.log();
 
     PersonaSwitcher.timer.cancel();
-};
+};*/
 
 // ---------------------------------------------------------------------------
 
@@ -430,11 +499,11 @@ PersonaSwitcher.switchTo = function (toWhich)
         as it seemed to add an additional default theme
     */
 
-    if (PersonaSwitcher.PersonasPlusPresent && 
+    /*if (PersonaSwitcher.PersonasPlusPresent && 
         PersonaSwitcher.prefs.getBoolPref ('notification-workaround'))
     {
         PersonaSwitcher.allWindows (PersonaSwitcher.removeNotification);
-    }
+    }*/
 };
 
 PersonaSwitcher.getPersonas = function()
@@ -466,15 +535,14 @@ PersonaSwitcher.previous = function()
 };
 
 /*
-** if the user pressed the rotate keyboard command, rotate and
-** reset the timer.
+** if the user pressed the rotate keyboard command
 */
 PersonaSwitcher.rotateKey = function()
 {
     PersonaSwitcher.logger.log("in rotateKey");
 
     PersonaSwitcher.rotate();
-    PersonaSwitcher.startTimer();
+    //PersonaSwitcher.startTimer();
 };
 
 PersonaSwitcher.setDefault = function()
@@ -482,7 +550,7 @@ PersonaSwitcher.setDefault = function()
     PersonaSwitcher.logger.log("in setDefault");
 
     PersonaSwitcher.switchTo (PersonaSwitcher.defaultTheme);
-    PersonaSwitcher.stopTimer();
+    //PersonaSwitcher.stopTimer();
 };
 
 PersonaSwitcher.onMenuItemCommand = function (which)
@@ -490,7 +558,7 @@ PersonaSwitcher.onMenuItemCommand = function (which)
     PersonaSwitcher.logger.log("in onMenuItemCommand");
 
     PersonaSwitcher.switchTo (which);
-    PersonaSwitcher.startTimer();
+    //PersonaSwitcher.startTimer();
 };
 
 PersonaSwitcher.migratePrefs = function()

--- a/chrome/content/PersonaSwitcher.jsm
+++ b/chrome/content/PersonaSwitcher.jsm
@@ -520,6 +520,7 @@ PersonaSwitcher.getPersonas = function()
                 concat (PersonaService.favorites);
         }
     }
+	PersonaSwitcher.currentThemes.sort (function (a, b) { return a.name.localeCompare (b.name); });
     PersonaSwitcher.logger.log (PersonaSwitcher.currentThemes.length);
 };
 

--- a/chrome/content/prefs.js
+++ b/chrome/content/prefs.js
@@ -60,7 +60,7 @@ pref ("extensions.personaswitcher.startup-switch", false);
 
 pref ("extensions.personaswitcher.fastswitch", false);
 
-pref ("extensions.personaswitcher.static-popups", false);
+//pref ("extensions.personaswitcher.static-popups", false);
 
 pref ("extensions.personaswitcher.current", 0);
 

--- a/chrome/content/prefs.js
+++ b/chrome/content/prefs.js
@@ -52,7 +52,7 @@ pref ("extensions.personaswitcher.main-menubar", false);
 pref ("extensions.personaswitcher.debug", true);
 pref ("extensions.personaswitcher.notification-workaround", true);
 
-pref ("extensions.personaswitcher.toolbox-minheight", "");
+pref ("extensions.personaswitcher.toolbox-minheight", "0");
 //If this changes, change it in the options.xul as well
 pref ("extensions.personaswitcher.toolbox-maxheight", "200");
 

--- a/chrome/content/ui.js
+++ b/chrome/content/ui.js
@@ -494,47 +494,6 @@ PersonaSwitcher.createMenuPopup = function (event)
     PersonaSwitcher.createMenuPopupWithDoc (doc, menupopup);
 };
 
-PersonaSwitcher.hideMenu = function (doc, which)
-{
-    var d = doc.getElementById ('personaswitcher-' + which);
-    if (d) d.hidden = true;
-};
-
-/*
-** remove a particular menu in all windows
-*/
-PersonaSwitcher.hideMenus = function (which)
-{
-    PersonaSwitcher.logger.log (which);
-
-    var enumerator = PersonaSwitcher.windowMediator.getEnumerator (null);
-
-    while (enumerator.hasMoreElements())
-    {
-        var doc = enumerator.getNext().document;
-        PersonaSwitcher.hideMenu (doc, which);
-    }
-};
-
-PersonaSwitcher.showMenu = function (doc, which)
-{
-    var d = doc.getElementById ('personaswitcher-' + which);
-    if (d) d.hidden = false;
-};
-
-PersonaSwitcher.showMenus = function (which)
-{
-    PersonaSwitcher.logger.log (which);
-
-    var enumerator = PersonaSwitcher.windowMediator.getEnumerator (null);
-
-    while (enumerator.hasMoreElements())
-    {
-        var doc = enumerator.getNext().document;
-        PersonaSwitcher.showMenu (doc, which);
-    }
-};
-
 //Appears to have been a Hack to get popupHidden to work in non-Firefox applications
 //Is no longer being called anywhere. Remove?
 PersonaSwitcher.popupShowing = function (event)
@@ -575,26 +534,6 @@ PersonaSwitcher.setAccessKey = function (doc)
     {
         var menu = doc.getElementById ('personaswitcher-main-menubar');
         menu.setAttribute ('accesskey', accesskey.toUpperCase().charAt(0));
-    }
-};
-
-// call a function passed as a parameter with one document of each window
-PersonaSwitcher.allDocuments = function (func)
-{	
-	var enumerator = PersonaSwitcher.windowMediator.getEnumerator ("navigator:browser");
-    while (enumerator.hasMoreElements())
-    {
-		func(enumerator.getNext().document);
-    }
-};
-
-// call a function passed as a parameter for each window
-PersonaSwitcher.allWindows = function (func)
-{
-	var enumerator = PersonaSwitcher.windowMediator.getEnumerator ("navigator:browser");
-    while (enumerator.hasMoreElements())
-    {
-		func(enumerator.getNext());
     }
 };
 
@@ -689,7 +628,7 @@ PersonaSwitcher.onWindowLoad = function (doc)
         // PersonaSwitcher.activeWindow = this;
         PersonaSwitcher.setLogger();
         PersonaSwitcher.logger.log ('first time');
-        PersonaSwitcher.startTimer();
+        //PersonaSwitcher.startTimer();
         PersonaSwitcher.getPersonas();
         PersonaSwitcher.themeMonitor();
 
@@ -717,6 +656,8 @@ PersonaSwitcher.onWindowLoad = function (doc)
     PersonaSwitcher.setKeyset (doc);
     PersonaSwitcher.setAccessKey (doc);
     PersonaSwitcher.setToolboxMinheight (doc);
+		
+		var mainMenu = PersonaSwitcher.prefs.getBoolPref ('main-menubar');
 
     if (! PersonaSwitcher.prefs.getBoolPref ('main-menubar'))
     {

--- a/chrome/content/ui.js
+++ b/chrome/content/ui.js
@@ -433,8 +433,6 @@ PersonaSwitcher.createMenuItems = function (doc, menupopup, arr)
         }
     //}
 
-    arr.sort (function (a, b) { return a.name.localeCompare (b.name); });
-
     for (var i = 0; i < arr.length; i++)
     {
         PersonaSwitcher.logger.log (i);

--- a/chrome/content/ui.js
+++ b/chrome/content/ui.js
@@ -433,7 +433,7 @@ PersonaSwitcher.createMenuItems = function (doc, menupopup, arr)
         }
     //}
 
-    // arr.sort (function (a, b) { return a.name.localeCompare (b.name); });
+    arr.sort (function (a, b) { return a.name.localeCompare (b.name); });
 
     for (var i = 0; i < arr.length; i++)
     {

--- a/webextension/background_scripts/WEPersonaSwitcher.js
+++ b/webextension/background_scripts/WEPersonaSwitcher.js
@@ -1,12 +1,10 @@
 function handleStartup() {
-	// Verify if we need to load the default preferences by checking if the 
-	// default_loaded flag is undefined. 
 	var checkDefaultsLoaded = browser.storage.local.get("defaults_loaded");
 	checkDefaultsLoaded
 	.then(loadDefaultsIfNeeded)
 	.then(setLogger)
 	.then(startRotateAlarm)
-	.then(getBuildMenuPromise)
+	.then(getMenuData)
 	.then(buildMenu)
 	.then(rotateOnStartup)
 	.then(function() {
@@ -15,6 +13,8 @@ function handleStartup() {
 	.catch(handleError);
 }
 
+// Verify if we need to load the default preferences by checking if the 
+// default_loaded flag is undefined. 
 function loadDefaultsIfNeeded(prefs) {
 		if(undefined === prefs.defaults_loaded) {
 			return loadDefaults();
@@ -83,7 +83,7 @@ function loadDefaults(){
 	return setting.then( function() {return Promise.resolve()}, handleError);
 }
 
-function getBuildMenuPromise() {
+function getMenuData() {
 		var menuPreferences = ["iconPreview", "preview", "previewDelay"];
 		var getData = Promise.all([
 				browser.storage.local.get(menuPreferences),
@@ -209,7 +209,7 @@ function stopRotateAlarm() {
 //the shortcuts can be migrated to the WebExtension code.
 function autoRotate() {
 	var checkRotatePref = Promise.all([
-		browser.storage.local.get(["auto"]),
+		browser.storage.local.get("auto"),
 		browser.runtime.sendMessage({command: "Return-Pref-Auto"})]);	
 		
 	checkRotatePref.then(results => {
@@ -287,12 +287,9 @@ function reactToPrefChange(prefName, prefData) {
 			toggleMenuIcons(prefData.newValue);
 			break;
 		case 'preview':
-			browser.runtime.sendMessage({command: "Set-Preference", preference: prefName, value: prefData.newValue});
-			getBuildMenuPromise().then(buildMenu, handleError);
-			break;
 		case 'previewDelay':
 			browser.runtime.sendMessage({command: "Set-Preference", preference: prefName, value: prefData.newValue});
-			getBuildMenuPromise().then(buildMenu, handleError);
+			getMenuData().then(buildMenu, handleError);
 			break;
 		case 'debug':
 			browser.runtime.sendMessage({command: "Set-Preference", preference: prefName, value: prefData.newValue});

--- a/webextension/background_scripts/WEPersonaSwitcher.js
+++ b/webextension/background_scripts/WEPersonaSwitcher.js
@@ -1,11 +1,27 @@
-// Verify if we need to load the default preferences by checking if the 
-// default_loaded flag is undefined. 
-var checkDefaultsLoaded = browser.storage.local.get("defaults_loaded");
-checkDefaultsLoaded.then(result => { if(undefined === result.defaults_loaded) {
-										loadDefaults();
-									}else{
-										onError(result.error);
-									}});
+function handleStartup() {
+	// Verify if we need to load the default preferences by checking if the 
+	// default_loaded flag is undefined. 
+	var checkDefaultsLoaded = browser.storage.local.get("defaults_loaded");
+	checkDefaultsLoaded
+	.then(loadDefaultsIfNeeded)
+	.then(setLogger)
+	.then(startRotateAlarm)
+	.then(getBuildMenuPromise)
+	.then(buildMenu)
+	.then(rotateOnStartup)
+	.then(function() {
+		return browser.storage.onChanged.addListener(handlePreferenceChange);
+	})
+	.catch(handleError);
+}
+
+function loadDefaultsIfNeeded(prefs) {
+		if(undefined === prefs.defaults_loaded) {
+			return loadDefaults();
+		} else {
+			return Promise.resolve();
+		}
+}
 
 function loadDefaults(){
 	var setting = browser.storage.local.set(
@@ -58,27 +74,296 @@ function loadDefaults(){
 			mainMenuBar: false,
 
 			//hidden preferences
-			debug: true,
-			notificationWorkaround: true,
+			debug: false,
 			toolboxMaxHeight: 200,
 			fastSwitch: false,
 			staticPopups: false,
 			current: 0
 		});
-	setting.catch(onError);
+	return setting.then( function() {return Promise.resolve()}, handleError);
 }
 
-function onError(error) {
-	console.log(`Error: ${error}`);
+function getBuildMenuPromise() {
+		var menuPreferences = ["iconPreview", "preview", "previewDelay"];
+		var getData = Promise.all([
+				browser.storage.local.get(menuPreferences),
+				browser.runtime.sendMessage({command: "Return-Theme-List"})
+		])
+		return getData;
 }
 
-// Handle the request message from options.js to load the defaults
-// after the user presses the reset button on the preferences menu.
-function handleMessage(request, sender, sendResponse) {
-  if("load defaults" === request.message){
-	loadDefaults();
-  	sendResponse({response: "defaults loaded"});
+var currentThemes;
+var browserActionMenu;
+function buildMenu(data) {
+	logger.log("Menu ", browserActionMenu);
+	browserActionMenu = document.createElement("div");
+	browserActionMenu.setAttribute("class", "menu");
+	currentThemes = data[1].themes;
+	for (var index = 0; index < currentThemes.length; index++) {		
+		browserActionMenu.appendChild(buildMenuItem(currentThemes[index], data[0]));
+	}
+	logger.log("Menu ", browserActionMenu);
+}
+
+function buildMenuItem(theme, prefs) {
+	var themeChoice = document.createElement("div");
+	themeChoice.setAttribute("class", "button theme");
+	var textNode = document.createTextNode(theme.name);
+	themeChoice.appendChild(textNode);
+	themeChoice.insertBefore(createIcon(theme.iconURL, prefs.iconPreview), textNode);
+	if(true === prefs.preview) {
+		themeChoice.addEventListener('mouseover', mouseOverListener(theme, prefs.previewDelay));
+		themeChoice.addEventListener('mouseout',  mouseOutListener(theme, prefs.preview));
+	}
+	themeChoice.addEventListener('click', clickListener(theme));
+	return themeChoice;
+}
+
+	
+function createIcon(iconURL, iconPreview) {
+	var themeImg = document.createElement("img");
+	themeImg.setAttribute("class", "button icon");
+	themeImg.setAttribute("src", iconURL);
+	if(false === iconPreview) {
+		themeImg.style.display = "none";
+	}
+	return themeImg;
+}
+
+var clickListener = function(theTheme) { 
+	return function() {
+		stopRotateAlarm(); 
+		browser.runtime.sendMessage({command: "Switch-Themes", theme: theTheme});
+		startRotateAlarm(); 
+	} 
+};
+
+var previewAlarmListener;
+var mouseOverListener = function(theTheme, previewDelay) { 
+	return function() { 
+		const when = Date.now() + previewDelay;
+		var innerAlarmListener = function(alarmInfo) {browser.runtime.sendMessage({command: "Preview-Theme", theme: theTheme}); };
+		previewAlarmListener = innerAlarmListener;
+		browser.alarms.create("previewAlarm", {when});
+		browser.alarms.onAlarm.addListener(previewAlarmListener);
+	}
+};
+
+var mouseOutListener = function(theTheme) { 
+	return function() { 
+		browser.alarms.clear("previewAlarm");
+		browser.alarms.onAlarm.removeListener(previewAlarmListener);
+		browser.runtime.sendMessage({command: "End-Preview", theme: theTheme}); 
+	}
+};
+
+function toggleMenuIcons(iconsShown) {
+	var displayValue;
+	if(true === iconsShown) {
+		displayValue = "inline";
+	} else {
+		displayValue = "none";
+	}		
+		icons = browserActionMenu.querySelectorAll(".icon");
+		for(i=0; i < icons.length; i++) {
+			logger.log("Icon Node", icons[i]);
+			icons[i].style.display = displayValue;
+		}
+}
+
+var rotateAlarmListener;
+function startRotateAlarm() {	
+	const ONE_SECOND = (1.0/60);
+	logger.log("In Rotate Alarm");
+	var checkRotatePref = browser.storage.local.get(["auto", "autoMinutes", "fastSwitch"]);
+	return checkRotatePref.then(results => { 
+		//Because the WebExtension can't be notified to turn on/off the rotate when the associated
+		//shortcut is pressed and processed in the bootstrap code, we have to run the alarm constantly.
+		//When the shorcuts are migrated over to the WebExtension replace the if(true) with if(true === results.auto)
+		if(true) {	
+			const periodInMinutes = results.fastSwitch ? ONE_SECOND : results.autoMinutes;
+			var innerAlarmListener = function(alarmInfo) {if ("rotateAlarm" === alarmInfo.name) {autoRotate()} };
+			rotateAlarmListener = innerAlarmListener;
+			browser.alarms.create("rotateAlarm", {periodInMinutes});
+			browser.alarms.onAlarm.addListener(rotateAlarmListener);
+		}
+		return Promise.resolve();
+	});
+}
+
+function stopRotateAlarm() {
+	if(undefined !== rotateAlarmListener) {
+		browser.alarms.clear("rotateAlarm");
+		browser.alarms.onAlarm.removeListener(rotateAlarmListener);		
+	}
+}
+
+//Because the legacy bootstrap code cannot initiate contact with the embedded WebExtension,
+//and because the shortcuts are still handled by the bootstrap code, when the shortcut
+//to toggle autoswitching is pressed the WebExtension is unable to react. Thus, we have to
+//check the bootstrap autoswitch preference before we rotate to make sure that the preference
+//is still true. Likewise, even if the preference in the WebExtension code is false, it may
+//have been toggled on by a shortcut key press in the bootstrap code. Thus we have to leave
+//the periodic timer continually running and only respond when the bootstrap code's auto
+//preference is true. This is not optimal from a performance standpoint but is necessary until
+//the shortcuts can be migrated to the WebExtension code.
+function autoRotate() {
+	var checkRotatePref = Promise.all([
+		browser.storage.local.get(["auto"]),
+		browser.runtime.sendMessage({command: "Return-Pref-Auto"})]);	
+		
+	checkRotatePref.then(results => {
+		if(true === results[1].auto) {
+			rotate();
+		}
+		
+		//If the two preferences don't match, update the WebExtension's pref
+		if(results[0].auto !== results[1].auto) {
+			browser.storage.local.set({auto: results[1].auto});
+		}
+	}, handleError);
+}
+
+function rotate() {
+	if (currentThemes.length <= 1) return;
+
+	//Because the shorcuts are still handled by the bootstrap code the currentIndex 
+	//in the bootstrap code is always as (or more) accurate than the currentIndex
+	//stored in the Webextension due to use of the rotate shortcut. 
+	var getRotatePref = Promise.all([
+		browser.storage.local.get("random"),
+		browser.runtime.sendMessage({command: "Get-Current-Index"})
+		]);
+	getRotatePref.then( results => {
+		var currentIndex = results[1].current;
+		logger.log ("Current index before ", currentIndex);
+		if (true === results[0].random)
+		{
+			var prevIndex = currentIndex;
+			// pick a number between 1 and the end until a new index is found
+			while(currentIndex === prevIndex) {
+				currentIndex = Math.floor ((Math.random() *
+						(currentThemes.length-1)) + 1);
+			}
+		}
+		else
+		{
+			currentIndex = (currentIndex + 1) %
+					currentThemes.length;
+		}
+
+		logger.log ("Current index after ", currentIndex);
+		var updatingCurrentIndex = browser.storage.local.set({current: currentIndex});
+		updatingCurrentIndex.catch(handleError);
+		browser.runtime.sendMessage({command: "Switch-Themes", theme: currentThemes[currentIndex]}); 
+	});
+	
+}
+
+function rotateOnStartup() {
+	logger.log("Rotate on Startup");
+	var checkRotateOnStartup = browser.storage.local.get("startupSwitch");
+	checkRotateOnStartup.then( prefs => {
+		if(true === prefs.startupSwitch) {
+			rotate();
+		}
+	});
+}
+
+function handlePreferenceChange(changes, area) { 
+  var changedPrefs = Object.keys(changes);
+ 
+  for (var pref of changedPrefs) {
+		if(undefined !== changes[pref].newValue && changes[pref].oldValue !== changes[pref].newValue) {
+			reactToPrefChange(pref, changes[pref]);
+		}
   }
 }
 
-browser.runtime.onMessage.addListener(handleMessage);
+function reactToPrefChange(prefName, prefData) {
+	switch(prefName) {
+		case 'iconPreview':
+			browser.runtime.sendMessage({command: "Set-Preference", preference: prefName, value: prefData.newValue});
+			toggleMenuIcons(prefData.newValue);
+			break;
+		case 'preview':
+			browser.runtime.sendMessage({command: "Set-Preference", preference: prefName, value: prefData.newValue});
+			getBuildMenuPromise().then(buildMenu, handleError);
+			break;
+		case 'previewDelay':
+			browser.runtime.sendMessage({command: "Set-Preference", preference: prefName, value: prefData.newValue});
+			getBuildMenuPromise().then(buildMenu, handleError);
+			break;
+		case 'debug':
+			browser.runtime.sendMessage({command: "Set-Preference", preference: prefName, value: prefData.newValue});
+			setLogger();
+			break;
+		case 'autoMinutes':
+			browser.runtime.sendMessage({command: "Set-Preference", preference: prefName, value: prefData.newValue});
+			stopRotateAlarm();
+			startRotateAlarm();
+		case 'auto':
+			//When the shortcuts are migrated to the WebExtension code, turn off/on the rotate timer here.
+		case 'toolboxMinHeight':
+		case 'startupSwitch':
+		case 'random':
+		case 'mainMenuBar':
+		case 'toolsMenu':
+		case 'defaultKeyShift':
+		case 'defaultKeyControl':
+		case 'defaultKeyAlt':
+		case 'defaultKeyMeta':
+		case 'defaultKeyAccel':
+		case 'defaultKeyOS':
+		case 'defaultKey':
+		case 'rotateKeyShift':
+		case 'rotateKeyControl':
+		case 'rotateKeyAlt':
+		case 'rotateKeyMeta':
+		case 'rotateKeyAccel':
+		case 'rotateKeyOS':
+		case 'rotateKey':
+		case 'autoKeyShift':
+		case 'autoKeyControl':
+		case 'autoKeyAlt':
+		case 'autoKeyMeta':
+		case 'autoKeyAccel':
+		case 'autoKeyOS':
+		case 'autoKey':
+		case 'accessKey':
+		case 'activateKeyShift':
+		case 'activateKeyControl':
+		case 'activateKeyAlt':
+		case 'activateKeyMeta':
+		case 'activateKeyAccel':
+		case 'activateKeyOs':
+		case 'activateKey':
+		case 'current':
+		case 'fastSwitch':
+			browser.runtime.sendMessage({command: "Set-Preference", preference: prefName, value: prefData.newValue});
+			break;
+		default:
+			logger.log(prefName, " " + prefData.newValue);
+	}
+}
+
+var logger;
+nullLogger = {};
+nullLogger.log = function (s) { 'use strict'; return; };
+function setLogger() {
+	var checkIfDebugging = browser.storage.local.get("debug");
+	return checkIfDebugging.then(result => {
+		if(true === result.debug) {
+			logger = console;
+		} else {
+			logger = nullLogger;
+		}		
+		return Promise.resolve();
+	});
+}
+
+function handleError(error) {
+	logger.log(`Error: ${error}`);
+};
+
+handleStartup();

--- a/webextension/background_scripts/WEPersonaSwitcher.js
+++ b/webextension/background_scripts/WEPersonaSwitcher.js
@@ -80,7 +80,7 @@ function loadDefaults(){
 			staticPopups: false,
 			current: 0
 		});
-	return setting.then( function() {return Promise.resolve()}, handleError);
+	return setting.then( function() {return Promise.resolve();}, handleError);
 }
 
 function getMenuData() {
@@ -88,7 +88,7 @@ function getMenuData() {
 		var getData = Promise.all([
 				browser.storage.local.get(menuPreferences),
 				browser.runtime.sendMessage({command: "Return-Theme-List"})
-		])
+		]);
 		return getData;
 }
 
@@ -135,7 +135,7 @@ var clickListener = function(theTheme) {
 		stopRotateAlarm(); 
 		browser.runtime.sendMessage({command: "Switch-Themes", theme: theTheme});
 		startRotateAlarm(); 
-	} 
+	};
 };
 
 var previewAlarmListener;
@@ -146,7 +146,7 @@ var mouseOverListener = function(theTheme, previewDelay) {
 		previewAlarmListener = innerAlarmListener;
 		browser.alarms.create("previewAlarm", {when});
 		browser.alarms.onAlarm.addListener(previewAlarmListener);
-	}
+	};
 };
 
 var mouseOutListener = function(theTheme) { 
@@ -154,7 +154,7 @@ var mouseOutListener = function(theTheme) {
 		browser.alarms.clear("previewAlarm");
 		browser.alarms.onAlarm.removeListener(previewAlarmListener);
 		browser.runtime.sendMessage({command: "End-Preview", theme: theTheme}); 
-	}
+	};
 };
 
 function toggleMenuIcons(iconsShown) {
@@ -164,10 +164,10 @@ function toggleMenuIcons(iconsShown) {
 	} else {
 		displayValue = "none";
 	}		
-		icons = browserActionMenu.querySelectorAll(".icon");
-		for(i=0; i < icons.length; i++) {
-			logger.log("Icon Node", icons[i]);
-			icons[i].style.display = displayValue;
+		var icons = browserActionMenu.querySelectorAll(".icon");
+		for(var index=0; index < icons.length; index++) {
+			logger.log("Icon Node", icons[index]);
+			icons[index].style.display = displayValue;
 		}
 }
 
@@ -182,7 +182,7 @@ function startRotateAlarm() {
 		//When the shorcuts are migrated over to the WebExtension replace the if(true) with if(true === results.auto)
 		if(true) {	
 			const periodInMinutes = results.fastSwitch ? ONE_SECOND : results.autoMinutes;
-			var innerAlarmListener = function(alarmInfo) {if ("rotateAlarm" === alarmInfo.name) {autoRotate()} };
+			var innerAlarmListener = function(alarmInfo) {if ("rotateAlarm" === alarmInfo.name) {autoRotate();} };
 			rotateAlarmListener = innerAlarmListener;
 			browser.alarms.create("rotateAlarm", {periodInMinutes});
 			browser.alarms.onAlarm.addListener(rotateAlarmListener);
@@ -299,6 +299,7 @@ function reactToPrefChange(prefName, prefData) {
 			browser.runtime.sendMessage({command: "Set-Preference", preference: prefName, value: prefData.newValue});
 			stopRotateAlarm();
 			startRotateAlarm();
+			break;
 		case 'auto':
 			//When the shortcuts are migrated to the WebExtension code, turn off/on the rotate timer here.
 		case 'toolboxMinHeight':
@@ -345,7 +346,7 @@ function reactToPrefChange(prefName, prefData) {
 }
 
 var logger;
-nullLogger = {};
+var nullLogger = {};
 nullLogger.log = function (s) { 'use strict'; return; };
 function setLogger() {
 	var checkIfDebugging = browser.storage.local.get("debug");
@@ -361,6 +362,6 @@ function setLogger() {
 
 function handleError(error) {
 	logger.log(`Error: ${error}`);
-};
+}
 
 handleStartup();

--- a/webextension/background_scripts/WEPersonaSwitcher.js
+++ b/webextension/background_scripts/WEPersonaSwitcher.js
@@ -77,7 +77,7 @@ function loadDefaults(){
 			debug: false,
 			toolboxMaxHeight: 200,
 			fastSwitch: false,
-			staticPopups: false,
+			staticMenus: true,
 			current: 0
 		});
 	return setting.then( function() {return Promise.resolve();}, handleError);

--- a/webextension/background_scripts/WEPersonaSwitcher.js
+++ b/webextension/background_scripts/WEPersonaSwitcher.js
@@ -345,6 +345,14 @@ function reactToPrefChange(prefName, prefData) {
 	}
 }
 
+browser.contextMenus.create({
+  id: "PSOptions",
+  title: "Persona Switcher Options",
+  contexts: ["browser_action"]
+});
+
+browser.contextMenus.onClicked.addListener((info) => { browser.runtime.openOptionsPage(); });
+
 var logger;
 var nullLogger = {};
 nullLogger.log = function (s) { 'use strict'; return; };

--- a/webextension/browser_action/popup.js
+++ b/webextension/browser_action/popup.js
@@ -1,7 +1,21 @@
 var backgroundPage;
 function appendMenu(page) {
 	backgroundPage = page;
-	document.body.appendChild(backgroundPage.browserActionMenu);
+	var getStaticPreference = browser.storage.local.get("staticMenus");
+	getStaticPreference.then((result) => {
+		backgroundPage.logger.log("Creating a new menu: " + !result.staticMenus);
+		if(false === result.staticMenus) {
+			var gettingMenuData = backgroundPage.getMenuData();
+			gettingMenuData
+			.then(backgroundPage.buildMenu)
+			.then(() => {
+				document.body.appendChild(backgroundPage.browserActionMenu);
+			})
+			.catch(backgroundPage.handleError);
+		} else {
+			document.body.appendChild(backgroundPage.browserActionMenu);
+		}
+	});
 }
 
 function removeMenu() {

--- a/webextension/browser_action/popup.js
+++ b/webextension/browser_action/popup.js
@@ -1,70 +1,23 @@
-//boolean that will be utilized by the preferences to choose to display the icon on the popup menu
-var showIcon = false;
-if (showIcon === true) {
-    var getThemes = browser.runtime.sendMessage({command: "Return-Theme-List-With-Icons"});
-    getThemes.then(buildMenuWithIcons, handleError);
-} else {
-    var getThemes = browser.runtime.sendMessage({command: "Return-Theme-List-With-No-Icons"});
-    getThemes.then(buildMenuNoIcons, handleError);
+var backgroundPage;
+function appendMenu(page) {
+	backgroundPage = page;
+	document.body.appendChild(backgroundPage.browserActionMenu);
 }
 
-function buildMenuWithIcons(themeList) {
-	var themes = themeList.themes;
-	for (var index = 0; index < themes.length; index++) {
-		var themeChoice = document.createElement("div");
-		themeChoice.setAttribute("class", "button theme");
-		var textNode = document.createTextNode(themes[index].name);
-		themeChoice.appendChild(textNode);
-		var themeImg = document.createElement("img");
-		themeImg.setAttribute("class", "button icon");
-		themeImg.setAttribute("src", themes[index].iconURL);
-		themeChoice.insertBefore(themeImg, textNode);
-		themeChoice.addEventListener('click', clickListener(themes[index]));
-		themeChoice.addEventListener('mouseover', mouseOverListener(themes[index]));
-		themeChoice.addEventListener('mouseout',  mouseOutListener(themes[index]));
-		document.body.appendChild(themeChoice);
-		console.log("ImgUrl: ", themes[index].iconURL);
-  }
+function removeMenu() {
+	document.body.removeChild(backgroundPage.browserActionMenu);
+	//The ownerDocument is set as the last DOM that the element was assigned to.
+	//If the menu's ownerDocument remains this window, it will be marked as a 
+	//deadObject when this window finishes unloading. Since we don't want to have
+	//to rebuild it, we need to assign it to a window that isn't going to
+	//be closed.
+	backgroundPage.document.body.appendChild(backgroundPage.browserActionMenu);
 }
-
-function buildMenuNoIcons(themeList) {
-	var themes = themeList.themes;
-	for (var index = 0; index < themes.length; index++) {
-		var themeChoice = document.createElement("div");
-		themeChoice.setAttribute("class", "button class");
-		var textNode = document.createTextNode(themes[index].name);
-		themeChoice.appendChild(textNode);	
-		themeChoice.addEventListener('click', clickListener(themes[index]));
-		themeChoice.addEventListener('mouseover', mouseOverListener(themes[index]));
-		themeChoice.addEventListener('mouseout',  mouseOutListener(themes[index]));
-		document.body.appendChild(themeChoice);
-		console.log("ImgUrl: ", themes[index].iconURL);
-  }
-}
-//Helper functions
-var clickListener = function(theTheme) { 
-		return function() { browser.runtime.sendMessage({command: "Switch-Themes", theme: theTheme}); } 
-	};
-
-var alarmListener;
-	var mouseOverListener = function(theTheme) { 
-		return function() { 
-			const when = Date.now()+1000;
-			var innerAlarmListener = function(alarmInfo) {browser.runtime.sendMessage({command: "Preview-Theme", theme: theTheme}); };
-			browser.alarms.create({when});
-			browser.alarms.onAlarm.addListener(innerAlarmListener);
-			alarmListener = innerAlarmListener;
-		}
-	};
-	
-	var mouseOutListener = function(theTheme) { 
-		return function() { 
-			browser.alarms.clearAll();
-			browser.alarms.onAlarm.removeListener(alarmListener);
-			browser.runtime.sendMessage({command: "End-Preview", theme: theTheme}); 
-		}
-	};
 
 function handleError(error) {
-console.log(`Error: ${error}`);
+	console.log(`Error: ${error}`);
 }
+
+var gettingBackgroundPage = browser.runtime.getBackgroundPage();
+gettingBackgroundPage.then(appendMenu);
+window.addEventListener("unload", removeMenu);

--- a/webextension/browser_action/popup.js
+++ b/webextension/browser_action/popup.js
@@ -14,10 +14,6 @@ function removeMenu() {
 	backgroundPage.document.body.appendChild(backgroundPage.browserActionMenu);
 }
 
-function handleError(error) {
-	console.log(`Error: ${error}`);
-}
-
 var gettingBackgroundPage = browser.runtime.getBackgroundPage();
 gettingBackgroundPage.then(appendMenu);
 window.addEventListener("unload", removeMenu);

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -45,6 +45,7 @@
   "permissions": [
 		"activeTab",
 		"tabs",
-    "storage"
+		"storage",
+		"alarms"
   ]
 }

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -46,6 +46,7 @@
 		"activeTab",
 		"tabs",
 		"storage",
-		"alarms"
+		"alarms",
+		"contextMenus"
   ]
 }


### PR DESCRIPTION
# browserAction
The creation and storage of the browserAction menu has been moved to the background script to allow it to be static. The menu is now always created with icon elements which are either shown or hidden depending on the relevant preference. The menu is still rebuilt each time the preview or previewDelay preferences are changed as those values are stored in closures attached to the menu and cannot be updated otherwise.

# Preference Changes are now Observed
Added a listener for changes to preferences in storage.local. Upon intercepting a valid change, the script reacts appropriately for all migrated functionality. At the moment this is mostly related to the browserAction menu and rotate functionality.

# Preferences Synced
When a preferences held in storage.local is changed it now triggers a message to be sent to the bootstrap code to update its equivalent preference with the new value.  

**NOTE:** This is a one way street due to the nature of embedded WebExtensions. Therefore, preferences which are changed by the bootstrap code **DO NOT** automatically update the equivalent preferences in storage.local. As such, special measures have been taken to query these preferences in the bootstrap code whenever they are needed. This mostly concerns the auto and current preferences.

# Rotate Functionality
Rotate functionality migrated to the WebExtension. Because the shortcuts are still handled by the bootstrap code, and the auto rotate functionality can be toggled by a shortcut, the auto rotate periodic alarm is currently set to run continuously. When the alarm triggers, the rotate is only performed if the auto preference is true. Changes to the autoMinutes preference will restart the timer with the new period value. Likewise, themes switched using the browser action will restart the timer. 

**NOTE:** Themes switched using the shortcut or the main menu or tools submenu **DO NOT** restart the timer as this happens purely in the bootstrap code which is unable to initiate communication with the embedded WebExtension.

# Bug Fixes
A serious case of **"How did that ever work?!!"**. Numerous bugs in bootstrap.js fixed, including user preferences not being removed on uninstall, default preferences being loaded (in a seperate context) after the preferences observer was set causing MANY PersonaSwitcher not defined exceptions, and others. Moved some functions from ui.js to PersonaSwitcher.jsm to facilitate bug fixes in bootstrap.js.