### PR TITLE
User Preference Retention on Upgrade/Downgrade

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -82,8 +82,9 @@ function install(data, reason) {
 }
 
 function uninstall(data, reason) {
-    firstRun = false;
-    removeUserPrefs();
+    if( ADDON_UNINSTALL === reason ) {
+        removeUserPrefs();
+    }
 }
 
 function loadIntoWindow(window) {

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -180,7 +180,12 @@ function injectMainMenu(doc) {
         false
     );
     menu_personaswitcher.appendChild(menu_PSPopup);
-    menuBar.insertBefore(menu_personaswitcher, menu_tools.nextSibling);
+    
+    if (null === menu_tools) {
+        menuBar.appendChild(menu_personaswitcher);
+    } else {
+        menuBar.insertBefore(menu_personaswitcher, menu_tools.nextSibling);        
+    }
 }
 
 function injectSubMenu(doc) {


### PR DESCRIPTION
User preferences will now be retained through the upgrade/downgrade process. Only during a true uninstall will the user preferences be cleared.

Also added a bug fix for when the tools menu is not present in the main menu toolbar.