### PR TITLE
Fixes for Complete Theme and Firefox Versions 17-28

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -265,7 +265,7 @@ function injectButton(window) {
     button.setAttribute("type", "menu");
     button.setAttribute("context", "");
     button.addEventListener("contextmenu", openOptions, true);
-    button.addEventListener("click", (e) => 
+    button.addEventListener("click", function(e) 
         {
             if(e.button === MIDDLE_BUTTON) PersonaSwitcher.setDefault();
         });

--- a/chrome/content/PersonaSwitcher.jsm
+++ b/chrome/content/PersonaSwitcher.jsm
@@ -493,21 +493,18 @@ PersonaSwitcher.switchTo = function (toWhich, index)
             PersonaSwitcher.logger.log();
             PersonaService.changeToPersona (toWhich);
         }
-    }
-    PersonaSwitcher.logger.log ('using currentTheme');
+    } else {
+        PersonaSwitcher.logger.log ('using themeChanged');
 
-    if (undefined === toWhich || null === toWhich)
-    {
-        LightweightThemeManager.currentTheme = null;
+        if ('undefined' === typeof(toWhich) || null === toWhich) {
+            LightweightThemeManager.themeChanged(null);
+        } else if('{972ce4c6-7e08-4474-a285-3208198ce6fd}' === toWhich.id) {
+            LightweightThemeManager.themeChanged(null);
+        } else {
+            LightweightThemeManager.themeChanged(toWhich);
     } 
-    else if('{972ce4c6-7e08-4474-a285-3208198ce6fd}' === toWhich.id)
-    {
-        LightweightThemeManager.currentTheme = null;
     }
-    else
-    {
-        LightweightThemeManager.currentTheme = toWhich;
-    }
+   
 };
 
 PersonaSwitcher.setCurrentTheme = function (doc, index)

--- a/chrome/content/PersonaSwitcher.jsm
+++ b/chrome/content/PersonaSwitcher.jsm
@@ -512,8 +512,7 @@ PersonaSwitcher.switchTo = function (toWhich, index)
 PersonaSwitcher.setCurrentTheme = function (doc, index)
 {
     var menus = ['personaswitcher-main-menubar-popup',
-        'personaswitcher-tools-submenu-popup',
-		'personaswitcher-button-popup'];
+        'personaswitcher-tools-submenu-popup'];
 
     for (var aMenu in menus)
     {
@@ -529,6 +528,18 @@ PersonaSwitcher.setCurrentTheme = function (doc, index)
 	            themes[index].setAttribute("checked", "true");
             }
         }
+    }
+
+    var buttonMenu = 
+            PersonaSwitcher.getButtonPopup(doc, 'personaswitcher-button');
+    if (null !== buttonMenu)
+    {        
+        var themes =  buttonMenu.children;
+            if(themes[PersonaSwitcher.currentIndex])
+            {
+                themes[PersonaSwitcher.currentIndex].removeAttribute("checked");
+	            themes[index].setAttribute("checked", "true");
+            }
     }
 };
 

--- a/chrome/content/PersonaSwitcher.jsm
+++ b/chrome/content/PersonaSwitcher.jsm
@@ -110,8 +110,11 @@ if (null === PersonaSwitcher.consoleLogger ||
     'SeaMonkey' === PersonaSwitcher.XULAppInfo.name)
 {
     // nope, log to terminal
+    var Application = Components.classes["@mozilla.org/steel/application;1"]
+                    .getService(Components.interfaces.steelIApplication);
+
     PersonaSwitcher.consoleLogger = {};
-    PersonaSwitcher.consoleLogger.log = PersonaSwitcher.log;
+    PersonaSwitcher.consoleLogger.log = Application.console.log;
 }
 
 PersonaSwitcher.nullLogger = {};

--- a/chrome/content/PersonaSwitcher.jsm
+++ b/chrome/content/PersonaSwitcher.jsm
@@ -535,11 +535,22 @@ PersonaSwitcher.setCurrentTheme = function (doc, index)
     if (null !== buttonMenu)
     {        
         var themes =  buttonMenu.children;
-            if(themes[PersonaSwitcher.currentIndex])
-            {
-                themes[PersonaSwitcher.currentIndex].removeAttribute("checked");
-	            themes[index].setAttribute("checked", "true");
-            }
+
+        PersonaSwitcher.logger.log(PersonaSwitcher.currentIndex);
+        if(themes[PersonaSwitcher.currentIndex])
+        {
+            PersonaSwitcher.logger.log(themes[PersonaSwitcher.currentIndex]);
+            themes[PersonaSwitcher.currentIndex].removeAttribute("checked");
+        }
+        if(themes[index])
+        {
+            PersonaSwitcher.logger.log(themes[index]);
+            theme = themes[index];
+            theme.setAttribute("checked", "true");
+            nextTheme = theme.nextSibling;
+            buttonMenu.removeChild(theme);
+            buttonMenu.insertBefore(theme, nextTheme);
+        }
     }
 };
 

--- a/chrome/content/PersonaSwitcher.jsm
+++ b/chrome/content/PersonaSwitcher.jsm
@@ -105,16 +105,18 @@ catch (e) {}
 // TBird's and SeaMonkey consoles don't log our stuff
 // this is a hack. i need to clean this up...
 // http://stackoverflow.com/questions/16686888/thunderbird-extension-console-logging
-if (null === PersonaSwitcher.consoleLogger ||
-    'Thunderbird' === PersonaSwitcher.XULAppInfo.name ||
-    'SeaMonkey' === PersonaSwitcher.XULAppInfo.name)
+if ('Thunderbird' === PersonaSwitcher.XULAppInfo.name)
 {
-    // nope, log to terminal
     var Application = Components.classes["@mozilla.org/steel/application;1"]
                     .getService(Components.interfaces.steelIApplication);
 
     PersonaSwitcher.consoleLogger = {};
     PersonaSwitcher.consoleLogger.log = Application.console.log;
+} else if (null === PersonaSwitcher.consoleLogger ||
+           'SeaMonkey' === PersonaSwitcher.XULAppInfo.name) {
+    // nope, log to terminal
+    PersonaSwitcher.consoleLogger = {};
+    PersonaSwitcher.consoleLogger.log = PersonaSwitcher.log;
 }
 
 PersonaSwitcher.nullLogger = {};

--- a/chrome/content/PersonaSwitcher.jsm
+++ b/chrome/content/PersonaSwitcher.jsm
@@ -547,6 +547,9 @@ PersonaSwitcher.setCurrentTheme = function (doc, index)
             PersonaSwitcher.logger.log(themes[index]);
             theme = themes[index];
             theme.setAttribute("checked", "true");
+            // This is a simple hack to ensure that the theme is redrawn in
+            // certain versions of Thunderbird while being run on a Mac.
+            //http://stackoverflow.com/questions/8840580/force-dom-redraw-refresh-on-chrome-mac
             nextTheme = theme.nextSibling;
             buttonMenu.removeChild(theme);
             buttonMenu.insertBefore(theme, nextTheme);

--- a/chrome/content/PersonaSwitcher.jsm
+++ b/chrome/content/PersonaSwitcher.jsm
@@ -278,7 +278,7 @@ PersonaSwitcher.allDocuments = function (func, index)
     {
         aWindow = enumerator.getNext();
         PersonaSwitcher.logger.log ('In allDocuments with ' + aWindow);
-        if (undefined !== index) 
+        if ('undefined' !== typeof(index)) 
         {
             func(aWindow.document, index);
         }
@@ -466,7 +466,7 @@ PersonaSwitcher.switchTo = function (toWhich, index)
     PersonaSwitcher.logger.log (toWhich);
     PersonaSwitcher.allDocuments(PersonaSwitcher.setCurrentTheme, index);
 
-    PersonaSwitcher.currentIndex = undefined !== index ? 
+    PersonaSwitcher.currentIndex = 'undefined' !== typeof(index) ? 
                                             index :
                                             PersonaSwitcher.currentIndex;
     
@@ -502,7 +502,7 @@ PersonaSwitcher.switchTo = function (toWhich, index)
             LightweightThemeManager.themeChanged(null);
         } else {
             LightweightThemeManager.themeChanged(toWhich);
-    } 
+        }
     }
    
 };

--- a/chrome/content/ui.js
+++ b/chrome/content/ui.js
@@ -180,8 +180,6 @@ PersonaSwitcher.activateMenu = function(doc)
 
 PersonaSwitcher.setToolboxMinheight = function(doc)
 {
-    PersonaSwitcher.logger.log();
-
     var minheight =
         parseInt (PersonaSwitcher.prefs.getCharPref('toolbox-minheight'));
     var maxheight =

--- a/chrome/skin/toolbar-button.css
+++ b/chrome/skin/toolbar-button.css
@@ -1,16 +1,17 @@
 #personaswitcher-button {
-  list-style-image: url("chrome://personaswitcher/skin/PersonaSwitcher24.png");
+  list-style-image: url("chrome://personaswitcher/skin/PersonaSwitcher24.png") !important;
 }
 
 toolbar[iconsize="small"] 
     #personaswitcher-button {
-    list-style-image: url("chrome://personaswitcher/skin/PersonaSwitcher16.png");
+    list-style-image: url("chrome://personaswitcher/skin/PersonaSwitcher16.png") !important;
 }
 
 toolbarpaletteitem[place="palette"] > #personaswitcher-button,
-    #personaswitcher-button[cui-areatype="menu-panel"] {
+    #personaswitcher-button[cui-areatype="menu-panel"],
+    #personaswitcher-button[cui-areatype="toolbar"] {
     list-style-image:
-        url("chrome://personaswitcher/skin/PersonaSwitcher32.png");
+        url("chrome://personaswitcher/skin/PersonaSwitcher32.png") !important;
 }
 
 toolbarpaletteitem[place="palette"] > 

--- a/install.rdf
+++ b/install.rdf
@@ -72,7 +72,7 @@
         <em:targetApplication>
           <Description>
             <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id> <!-- Firefox -->
-            <em:minVersion>29.*</em:minVersion>
+            <em:minVersion>17.*</em:minVersion>
             <em:maxVersion>54.*</em:maxVersion>
           </Description>
         </em:targetApplication>
@@ -88,7 +88,7 @@
         <em:targetApplication>
           <Description>
             <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id> <!-- Thunderbird -->
-            <em:minVersion>10.0</em:minVersion>
+            <em:minVersion>13.*</em:minVersion>
             <em:maxVersion>45.*</em:maxVersion>
           </Description>
         </em:targetApplication>

--- a/install.rdf
+++ b/install.rdf
@@ -88,7 +88,7 @@
         <em:targetApplication>
           <Description>
             <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id> <!-- Thunderbird -->
-            <em:minVersion>13.*</em:minVersion>
+            <em:minVersion>13.0.1</em:minVersion>
             <em:maxVersion>45.*</em:maxVersion>
           </Description>
         </em:targetApplication>

--- a/install.rdf
+++ b/install.rdf
@@ -88,7 +88,7 @@
         <em:targetApplication>
           <Description>
             <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id> <!-- Thunderbird -->
-            <em:minVersion>13.*</em:minVersion>
+            <em:minVersion>13.0</em:minVersion>
             <em:maxVersion>45.*</em:maxVersion>
           </Description>
         </em:targetApplication>

--- a/install.rdf
+++ b/install.rdf
@@ -72,7 +72,7 @@
         <em:targetApplication>
           <Description>
             <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id> <!-- Firefox -->
-            <em:minVersion>17.*</em:minVersion>
+            <em:minVersion>17.0</em:minVersion>
             <em:maxVersion>54.*</em:maxVersion>
           </Description>
         </em:targetApplication>


### PR DESCRIPTION
### Complete Theme
The code was previously using  the outdated mode of changing themes by assigning to currentTheme rather than calling themeChanged(). This seems to have been the issue that caused the incompatibility with Complete Themes.

**Note:** While Persona Switcher will now work with complete themes, depending upon the specific complete theme, the persona that is assigned by Persona Switcher may not change any visible elements due to those elements being already controlled by the complete theme. Walnut2 is an example of such a Complete Theme.

### Thunderbird on Mac
Implemented forced update and redraw for menu items in the button's menu to solve issues where certain versions of Thunderbird run on a Mac would not display the updated(checked) menu item leading to the perception that the current theme was not being tracked.

### Firefox Versions 17-22
The Persona Switcher button displaying a default icon seems to have been caused by other stylesheets overriding our CSS. !important tags were added to all our CSS rules and the icon is now always displaying properly.

### Firefox Versions 23-28
The assumption that the button was not installing was a mistake. The button is getting installed and handled properly. It's just that it's getting loaded into the navigation toolbar which these versions hide when the about:Addons tab is selected. By navigating to another tab one is able to see that the button has been loaded and is functioning correctly.

### Thunderbird Logging
Added in logging to the error console for Thunderbird  to help facilitate testing.

### Fix for Updating Current Theme when Button is in the Palette
Added a fix that updates the currently selected theme even when the button is not active on a toolbar.

### Updated Min Versions for Firefox and Thunderbird
Updated the Firefox min version to 17.0 and Thunderbird to 13.0 as the current testing shows these and subsequent versions to be working correctly with Persona Switcher.