### PR TITLE
Default Theme Segregation

### DIFF
--- a/chrome/content/PersonaSwitcher.jsm
+++ b/chrome/content/PersonaSwitcher.jsm
@@ -706,7 +706,8 @@ PersonaSwitcher.rotateKey = function()
 PersonaSwitcher.setDefault = function()
 {
     PersonaSwitcher.logger.log("in setDefault");
-    var indexOfDefault = PersonaSwitcher.currentThemes.length;
+    var indexOfDefault = PersonaSwitcher.currentThemes.length + 
+                            PersonaSwitcher.defaultThemes.length;
     PersonaSwitcher.switchTo (PersonaSwitcher.defaultTheme, indexOfDefault);
     PersonaSwitcher.stopTimer();
 };

--- a/chrome/content/PersonaSwitcher.jsm
+++ b/chrome/content/PersonaSwitcher.jsm
@@ -593,6 +593,7 @@ PersonaSwitcher.setCurrentTheme = function (doc, index)
 
 PersonaSwitcher.updateIndexOnRemove = function(newTheme, currentTheme) {
     PersonaSwitcher.logger.log(newTheme + " " + currentTheme);
+
     switch(newTheme.localeCompare(currentTheme)) 
     {
         case APPEARS_HIGHER_IN_LIST:
@@ -604,19 +605,26 @@ PersonaSwitcher.updateIndexOnRemove = function(newTheme, currentTheme) {
         case SAME:
             // If the current theme is the one that gets removed, the theme is
             // set to the default.
-            PersonaSwitcher.prefs.setIntPref('current', PersonaSwitcher.currentThemes.length);
-            PersonaSwitcher.currentIndex = PersonaSwitcher.currentThemes.length;
-            PersonaSwitcher.logger.log("New Index: " + PersonaSwitcher.currentIndex);
+            var newIndex = PersonaSwitcher.currentThemes.length + 
+                                PersonaSwitcher.defaultThemes.length - 1;
+            PersonaSwitcher.prefs.setIntPref('current', newIndex);
+            PersonaSwitcher.currentIndex = newIndex;
+            PersonaSwitcher.logger.log("New Index: " + newIndex);
             break;
-        case APPEARS_LOWER_IN_LIST:
-            //No need to change,
+        case APPEARS_LOWER_IN_LIST:            
+            if(isDefaultTheme(currentTheme)) {
+                var index = PersonaSwitcher.prefs.getIntPref('current');
+                index--;
+                PersonaSwitcher.prefs.setIntPref('current', index);
+                PersonaSwitcher.currentIndex = index;
+            }
             break;
         default:
             break;
     }
 };
 
-PersonaSwitcher.updateIndexOnAdd = function(newTheme, currentTheme) {
+PersonaSwitcher.updateIndexOnAdd = function(newTheme) {
     var index;
     for (index = 0; index < PersonaSwitcher.currentThemes.length; index++) {
         if(APPEARS_HIGHER_IN_LIST === newTheme.localeCompare(PersonaSwitcher.currentThemes[index].name)) {
@@ -624,11 +632,11 @@ PersonaSwitcher.updateIndexOnAdd = function(newTheme, currentTheme) {
             PersonaSwitcher.currentIndex = index;
             return;
         }
-        //Otherwise the new theme will be at the bottom of the list
-        PersonaSwitcher.prefs.setIntPref('current', index);
-        PersonaSwitcher.currentIndex = index;
-
     }
+    
+    //Otherwise the new theme will be at the bottom of the list
+    PersonaSwitcher.prefs.setIntPref('current', index);
+    PersonaSwitcher.currentIndex = index;
 };
 
 PersonaSwitcher.getPersonas = function()

--- a/chrome/content/ui.js
+++ b/chrome/content/ui.js
@@ -235,7 +235,7 @@ PersonaSwitcher.AddonListener =
         if('undefined' === typeof(PersonaSwitcher)) {
             return;
         }
-        
+
         PersonaSwitcher.logger.log (addon.type);
         PersonaSwitcher.logger.log (addon.name);
         
@@ -657,7 +657,6 @@ PersonaSwitcher.onWindowLoad = function (doc)
         PersonaSwitcher.setLogger();
         PersonaSwitcher.logger.log ('first time');
         PersonaSwitcher.startTimer();
-        PersonaSwitcher.getPersonas();
         PersonaSwitcher.themeMonitor();
 
         // Due to the asynchronous call to the addon manager, this also sets up

--- a/chrome/content/ui.js
+++ b/chrome/content/ui.js
@@ -334,6 +334,11 @@ PersonaSwitcher.previewObserver =
     }
 };
 
+PersonaSwitcher.insertSeparator = function(doc, menupopup) {
+    var separator = doc.createElement("menuseparator");
+    menupopup.appendChild(separator);
+};
+
 /*
 ** create a menuitem, possibly creating a preview
 */
@@ -428,12 +433,12 @@ PersonaSwitcher.createMenuItem = function (doc, which, index)
     return (item);
 };
 
-PersonaSwitcher.createMenuItems = function (doc, menupopup, arr)
+PersonaSwitcher.createMenuItems = function (doc, menupopup, arr, indexOffset)
 {
     PersonaSwitcher.logger.log(menupopup.id);
+    indexOffset = 'undefined' === typeof(indexOffset) ? 0 : indexOffset;
 
     var popup = 'personaswitcher-button-popup' ===  menupopup.id;
-    // PersonaSwitcher.logger.log (popup);
 
     var item = null;
 
@@ -441,41 +446,12 @@ PersonaSwitcher.createMenuItems = function (doc, menupopup, arr)
     {
         PersonaSwitcher.logger.log (i);
         PersonaSwitcher.logger.log (arr[i]);
-        item = PersonaSwitcher.createMenuItem(doc, arr[i], i);
+        item = PersonaSwitcher.createMenuItem(doc, arr[i], i + indexOffset);
         if (item)
         {
             menupopup.appendChild(item);
         }
     }
-
-    /*
-    // the bad two cases when having a default messes with the menu
-    // if it's thunderbird and we stretched the top
-    var TBird = 'Thunderbird' === PersonaSwitcher.XULAppInfo.name;
-    var chars = PersonaSwitcher.prefs.getCharPref ('toolbox-minheight');
-    var height = parseInt (chars);
-    height = isNaN (height) ? 0 : height;
-    var stretched = 0 !== height;
-
-    var TB = TBird && stretched && popup;
-    PersonaSwitcher.logger.log (TB);
-
-    // it's pale moon, a menubar, and preview is set
-    var PM = 'personaswitcher-button-popup' ===  menupopup.id &&
-        'Pale Moon' === PersonaSwitcher.XULAppInfo.name &&
-        PersonaSwitcher.prefs.getBoolPref ('preview');
-    PersonaSwitcher.logger.log (PM);
-    */
-
-    //if (!PM && !TB && null !== PersonaSwitcher.defaultTheme)
-    //{
-        item = PersonaSwitcher.createMenuItem
-            (doc, PersonaSwitcher.defaultTheme, arr.length);
-        if (item)
-        {
-            menupopup.appendChild (item);
-        }
-    //}
 };
 
 PersonaSwitcher.createMenuPopupWithDoc = function (doc, menupopup)
@@ -489,9 +465,11 @@ PersonaSwitcher.createMenuPopupWithDoc = function (doc, menupopup)
         menupopup.removeChild(menupopup.firstChild);
     }
 
-    var arr = PersonaSwitcher.currentThemes;
+    var themes = PersonaSwitcher.currentThemes;
+    var defaults = PersonaSwitcher.defaultThemes;
+    var indexOffset = PersonaSwitcher.currentThemes.length+1;
 
-    if (0 === arr.length)
+    if (0 === themes.length)
     {
         PersonaSwitcher.logger.log('no themes');
 
@@ -506,7 +484,9 @@ PersonaSwitcher.createMenuPopupWithDoc = function (doc, menupopup)
     }
     else
     {
-        PersonaSwitcher.createMenuItems(doc, menupopup, arr);
+        PersonaSwitcher.createMenuItems(doc, menupopup, themes);
+        PersonaSwitcher.insertSeparator(doc, menupopup);
+        PersonaSwitcher.createMenuItems(doc, menupopup, defaults, indexOffset);
     }
 };
 

--- a/chrome/content/ui.js
+++ b/chrome/content/ui.js
@@ -601,7 +601,7 @@ PersonaSwitcher.getButtonPopup =  function(doc, id)
     return doc.getElementById('personaswitcher-button-popup');
 };
 
-PersonaSwitcher.setDefaultTheme = function (doc)
+PersonaSwitcher.setDefaultTheme = function (resolve, reject)
 {
     PersonaSwitcher.logger.log('in setDefaultTheme');
 
@@ -618,12 +618,7 @@ PersonaSwitcher.setDefaultTheme = function (doc)
                 {
                     PersonaSwitcher.defaultTheme = theme;
                 }
-                PersonaSwitcher.createStaticPopups(doc);
-                PersonaSwitcher.currentIndex =
-                    PersonaSwitcher.prefs.getIntPref ("current");
-                PersonaSwitcher.switchTo 
-                    (PersonaSwitcher.currentThemes[PersonaSwitcher.currentIndex],
-                     PersonaSwitcher.currentIndex);
+                resolve();
             }
         );
     }
@@ -636,13 +631,7 @@ PersonaSwitcher.setDefaultTheme = function (doc)
         {
             PersonaSwitcher.defaultTheme = theme;
         }
-        
-        PersonaSwitcher.createStaticPopups(doc);
-        PersonaSwitcher.currentIndex =
-            PersonaSwitcher.prefs.getIntPref ("current");
-        PersonaSwitcher.switchTo 
-            (PersonaSwitcher.currentThemes[PersonaSwitcher.currentIndex],
-             PersonaSwitcher.currentIndex);
+        resolve();
     }
 };
 
@@ -659,15 +648,22 @@ PersonaSwitcher.onWindowLoad = function (doc)
         PersonaSwitcher.startTimer();
         PersonaSwitcher.themeMonitor();
 
-        // Due to the asynchronous call to the addon manager, this also sets up
-        // the menus, assigns the current index and switches to the current 
-        // theme. bleah.
-        PersonaSwitcher.setDefaultTheme(doc);
+        var retrieveDefaultTheme = new Promise(PersonaSwitcher.setDefaultTheme);
 
-        if (PersonaSwitcher.prefs.getBoolPref ('startup-switch'))
-        {
-            PersonaSwitcher.rotate();
-        }
+        retrieveDefaultTheme.then(() => {
+            PersonaSwitcher.createStaticPopups(doc);
+            PersonaSwitcher.currentIndex =
+                PersonaSwitcher.prefs.getIntPref ("current");
+
+            if (PersonaSwitcher.prefs.getBoolPref ('startup-switch'))
+            {
+                PersonaSwitcher.rotate();
+            } else {
+                PersonaSwitcher.switchTo 
+                    (PersonaSwitcher.currentThemes[PersonaSwitcher.currentIndex],
+                     PersonaSwitcher.currentIndex);
+            }
+        });
     }
     else
     {

--- a/chrome/content/ui.js
+++ b/chrome/content/ui.js
@@ -232,16 +232,16 @@ PersonaSwitcher.AddonListener =
     // pane and don't need to be monitored
     onInstalled: function (addon)
     {
-        var currentThemeName = 
-            PersonaSwitcher.currentThemes[
-                                PersonaSwitcher.prefs.getIntPref('current')
-                            ].name;
+        if('undefined' === typeof(PersonaSwitcher)) {
+            return;
+        }
+        
         PersonaSwitcher.logger.log (addon.type);
         PersonaSwitcher.logger.log (addon.name);
         
         if ('theme' === addon.type)
         {
-            PersonaSwitcher.updateIndexOnAdd(addon.name, currentThemeName);
+            PersonaSwitcher.updateIndexOnAdd(addon.name);
             PersonaSwitcher.allDocuments(PersonaSwitcher.createStaticPopups);
         }
     },
@@ -250,16 +250,21 @@ PersonaSwitcher.AddonListener =
         if('undefined' === typeof(PersonaSwitcher)) {
             return;
         }
-        var currentThemeName = 
-            PersonaSwitcher.currentThemes[
-                                PersonaSwitcher.prefs.getIntPref('current')
-                            ].name;
+
+        var currentThemeName;
+        var currentIndex = PersonaSwitcher.prefs.getIntPref('current');
+
+        if(PersonaSwitcher.currentThemes.length > currentIndex) { 
+            currentThemeName = PersonaSwitcher.currentThemes[currentIndex].name;
+        } else {
+            currentIndex -= PersonaSwitcher.currentThemes.length;
+            currentThemeName = PersonaSwitcher.defaultThemes[currentIndex].name;
+        }
         PersonaSwitcher.logger.log (addon.type);
         PersonaSwitcher.logger.log (addon.name);
         
         if ('theme' === addon.type)
         {
-            PersonaSwitcher.getPersonas();
             PersonaSwitcher.updateIndexOnRemove(addon.name, currentThemeName);
             PersonaSwitcher.allDocuments(PersonaSwitcher.createStaticPopups);
         }


### PR DESCRIPTION

### Default Theme Segregation

Default Themes are now segregated at the bottom of the menu. This is done by pulling the default themes out of the PersonaSwitcher.currentThemes array and storing them in their own array. When the menus are built, the current themes are added, a menuseparator is added and then the default themes are added. This also removed the need to blacklist the defaults when rotating as they are no longer in the list of themes that are rotated through. 
* When rotating with a default theme active, if the random preference is false, the rotate will proceed to the first theme in the list. 